### PR TITLE
Workaround lineageos bug

### DIFF
--- a/keyboard_led_brightness.sh
+++ b/keyboard_led_brightness.sh
@@ -21,5 +21,11 @@ elif [[ ${LCD_VALUE} == '0' ]]; then
 
 	echo 0 > /sys/class/leds/mt6370_pmu_led1/brightness
 	echo 0 > /sys/class/leds/mt6370_pmu_led2/brightness
+
+	# Sometime, the keyboard flickers and remains enabled, even if LCD is off.
+	sleep 0.333
+	echo 0 > /sys/class/leds/mt6370_pmu_led1/brightness
+	echo 0 > /sys/class/leds/mt6370_pmu_led2/brightness
+
 fi
 exit 0


### PR DESCRIPTION
On lineageos the keyboard leds switch on again after a short time after display turned off.

I use the unofficial lineage rom https://forum.xda-developers.com/t/rom-beta-unoffical-lineageos-18-1-for-xiaomi-qin-f21s-pro-by-a-i-v.4431693/.